### PR TITLE
Added a /healthcheck endpoint (middleware) to enable monitoring

### DIFF
--- a/app/middleware/health_check.rb
+++ b/app/middleware/health_check.rb
@@ -1,0 +1,28 @@
+# app/lib/middlewares/healthcheck.rb
+
+##
+# This class implements a middlware for checking if the application is responding
+# to requests.
+class HealthCheck
+  PAYLOAD = ['{"status": "ok"}']
+  HEADER = {"Content-Type" => "application/json"}
+
+  def initialize(app)
+    @app = app
+  end
+
+  # To assure thread safety, every call will be performed on a duplicated object
+  # assuring that the instance variables remains isolated per thread.
+  def call(env)
+    dup.__call(env)
+  end
+
+  # Any instance variable assigned here will be thread-safe.
+  def __call(env)
+    if env["REQUEST_URI"] == "/healthcheck".freeze
+      return [200, HEADER, PAYLOAD]
+    else
+      @app.call(env)
+    end
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -44,4 +44,7 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # Custom middlewares
+  config.middleware.insert_after Rails::Rack::Logger, HealthCheck
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -80,4 +80,7 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  # Custom middlewares
+  config.middleware.insert_after Rails::Rack::Logger, HealthCheck
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,4 +39,7 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Custom middlewares
+  config.middleware.insert_after Rails::Rack::Logger, HealthCheck
 end

--- a/spec/requests/health_check_spec.rb
+++ b/spec/requests/health_check_spec.rb
@@ -1,0 +1,10 @@
+# spec/requests/health_check_spec.rb
+require 'rails_helper'
+
+RSpec.describe HealthCheck, type: :request do
+  before { get '/healthcheck' }
+
+  it "should be healty" do
+    expect(response).to have_http_status(:ok)
+  end
+end


### PR DESCRIPTION
Monitoring of the Rack application can be done by reaching the /healthcheck endpoint.

Expected result: 200 status code and a json with the following content:
{"status": "ok"}
